### PR TITLE
[oobe] init settings window when oobe starts

### DIFF
--- a/src/settings-ui/PowerToys.Settings/App.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/App.xaml.cs
@@ -29,6 +29,26 @@ namespace PowerToys.Settings
             settingsWindow.NavigateToSection(type);
         }
 
+        private void InitHiddenSettingsWindow()
+        {
+            settingsWindow = new MainWindow();
+
+            // To avoid visual flikering, show the window with a size of 0,0
+            // and don't show it in the taskbar
+            var originalHight = settingsWindow.Height;
+            var originalWidth = settingsWindow.Width;
+            settingsWindow.Height = 0;
+            settingsWindow.Width = 0;
+            settingsWindow.ShowInTaskbar = false;
+
+            settingsWindow.Show();
+            settingsWindow.Hide();
+
+            settingsWindow.Height = originalHight;
+            settingsWindow.Width = originalWidth;
+            settingsWindow.ShowInTaskbar = true;
+        }
+
         private void Application_Startup(object sender, StartupEventArgs e)
         {
             if (!ShowOobe)
@@ -40,8 +60,13 @@ namespace PowerToys.Settings
             {
                 PowerToysTelemetry.Log.WriteEvent(new OobeStartedEvent());
 
-                OobeWindow otherWindow = new OobeWindow();
-                otherWindow.Show();
+                // Create the Settings window so that it's fully initialized and
+                // it will be ready to receive the notification if the user opens
+                // the Settings from the tray icon.
+                InitHiddenSettingsWindow();
+
+                OobeWindow oobeWindow = new OobeWindow();
+                oobeWindow.Show();
             }
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
